### PR TITLE
baseline shift param for individual caterpillars

### DIFF
--- a/mcmcplots/R/caterplot.R
+++ b/mcmcplots/R/caterplot.R
@@ -1,4 +1,4 @@
-caterplot <- function (mcmcout, parms=NULL, regex=NULL, random=NULL, leaf.marker="[\\[_]", quantiles=list(), collapse=TRUE, denstrip = FALSE, add = FALSE, labels=NULL, labels.loc="axis", las = NULL, cex.labels=NULL, greek = FALSE, horizontal=TRUE, val.lim=NULL, lab.lim=NULL, lwd=c(1, 2), pch=16, eps=0.1, width=NULL, col=NULL, style=c("gray", "plain"), ...){
+caterplot <- function (mcmcout, parms=NULL, regex=NULL, random=NULL, leaf.marker="[\\[_]", quantiles=list(), collapse=TRUE, denstrip = FALSE, add = FALSE, labels=NULL, labels.loc="axis", las = NULL, cex.labels=NULL, greek = FALSE, horizontal=TRUE, val.lim=NULL, lab.lim=NULL, lwd=c(1, 2), pch=16, eps=0.1, width=NULL, col=NULL, ybase=0, style=c("gray", "plain"), ...){
 
     ## Utility functions ##
     is.odd <- function(x) return(x %% 2 != 0)
@@ -76,7 +76,7 @@ caterplot <- function (mcmcout, parms=NULL, regex=NULL, random=NULL, leaf.marker
 
         if (is.null(las)) las <- 1
 
-        vv <- rev(seq(np))
+        vv <- rev(seq(np)) + ybase
     }
     else{
         ylim <- val.lim
@@ -96,7 +96,7 @@ caterplot <- function (mcmcout, parms=NULL, regex=NULL, random=NULL, leaf.marker
         axis.side <- 1
         if (is.null(las)) las <- 2
 
-        vv <- seq(np)
+        vv <- seq(np) + ybase
     }
 
     if(style=="gray"){

--- a/mcmcplots/man/caterplot.Rd
+++ b/mcmcplots/man/caterplot.Rd
@@ -13,7 +13,7 @@ leaf.marker = "[\\\\[_]", quantiles
 = list(), collapse = TRUE, denstrip = FALSE, add = FALSE, labels = NULL,
 labels.loc = "axis", las = NULL, cex.labels = NULL, greek = FALSE,
 horizontal=TRUE, val.lim = NULL, lab.lim = NULL, lwd = c(1, 2), pch =
-16, eps = 0.1, width = NULL, col = NULL,
+16, eps = 0.1, width = NULL, col = NULL, ybase=0,
 style=c("gray", "plain"), \dots)
 }
 
@@ -41,6 +41,7 @@ style=c("gray", "plain"), \dots)
   \item{eps}{controls the spacing between parallel caterpillars when \code{collapse=FALSE}}
   \item{width}{width of the density strips.}
   \item{style}{if "gray", then the plotting region is printed with a gray background, otherwise the default plotting region is used.}
+  \item{ybase}{if larger 0 "caterpillars" are translated up (left), if smaller 0 "caterpillars" are translated down (right) by the amount \code{ybase}.}
   \item{\ldots}{further arguments passed to the plotting function.}
 }
 
@@ -106,6 +107,11 @@ caterplot(fakemcmc, col="purple", pch=19, add=TRUE)
 varnames(fakemcmc) <- NULL
 caterplot(fakemcmc)
 caterplot(fakemcmc, collapse=FALSE)
+
+## Overlay caterplots 
+caterplot(fakemcmc, "alpha", collapse=TRUE)
+caterplot(fakemcmc, "gamma", collapse=TRUE, add=TRUE, ybase=-0.3)
+
 
 \dontrun{
 ## caterplot works on bugs objects too:


### PR DESCRIPTION
included a new parameter in caterplot to allow for shifts up/down
left/right of individual caterpillars. can be useful to overlay
caterplots, see example in doc.