### PR TITLE
Make browsing final HTML file optional.

### DIFF
--- a/mcmcplots/R/mcmcplot.R
+++ b/mcmcplots/R/mcmcplot.R
@@ -1,4 +1,4 @@
-mcmcplot <- function(mcmcout, parms=NULL, regex=NULL, random=NULL, leaf.marker="[\\[_]", dir=tempdir(), filename="MCMCoutput", extension="html", title=NULL, heading=title, col=NULL, lty=1, xlim=NULL, ylim=NULL, style=c("gray", "plain"), greek=FALSE){
+mcmcplot <- function(mcmcout, parms=NULL, regex=NULL, random=NULL, leaf.marker="[\\[_]", dir=tempdir(), filename="MCMCoutput", extension="html", title=NULL, heading=title, col=NULL, lty=1, xlim=NULL, ylim=NULL, style=c("gray", "plain"), greek=FALSE, browse=TRUE){
     ## This must come before mcmcout is evaluated in any other expression
     if (is.null(title))
         title <- paste("MCMC Plots: ", deparse(substitute(mcmcout)), sep="")
@@ -69,6 +69,6 @@ mcmcplot <- function(mcmcout, parms=NULL, regex=NULL, random=NULL, leaf.marker="
     cat('\n</div>\n</div>\n', file=htmlfile, append=TRUE)
     .html.end(htmlfile)
     full.name.path <- paste("file://", htmlfile, sep="")
-    browseURL(full.name.path)
+    if (browse) browseURL(full.name.path)
     invisible(full.name.path)
 }

--- a/mcmcplots/man/mcmcplot.Rd
+++ b/mcmcplots/man/mcmcplot.Rd
@@ -33,6 +33,7 @@ style=c("gray", "plain"), greek = FALSE)
   \item{ylim}{ limits for the y axis of the density plot.}
   \item{style}{ if "gray", then the plotting region is printed with a gray background, otherwise the default plotting region is used.}
   \item{greek}{if \code{TRUE}, the names of greek letters in the \code{labels} will be displayed as greek characters on the plot.}
+  \item{browse}{if \code{TRUE}, the html file will be opened up in a browser window using \code{\link{browseURL}}}
 }
 
 \details{


### PR DESCRIPTION
This patch allows the user of `mcmcplot` to select whether to browse the final HTML file the function produces. This can be useful if the user is interested in saving the HTML output for later review (by specifying a `dir` and `filename` when calling the function).
