### PR TITLE
Fix for bug when path is relative.

### DIFF
--- a/mcmcplots/R/mcmcplot.R
+++ b/mcmcplots/R/mcmcplot.R
@@ -68,7 +68,7 @@ mcmcplot <- function(mcmcout, parms=NULL, regex=NULL, random=NULL, leaf.marker="
     cat("\r", rep(" ", getOption("width")), "\r", sep="")
     cat('\n</div>\n</div>\n', file=htmlfile, append=TRUE)
     .html.end(htmlfile)
-    full.name.path <- paste("file://", htmlfile, sep="")
+    full.name.path <- paste("file://", normalizePath(htmlfile), sep="")
     browseURL(full.name.path)
     invisible(full.name.path)
 }


### PR DESCRIPTION
This patch fixes a bug where the call to `browseURL` fails if `htmlfile` is a relative path. I encountered this bug on Windows - I haven't tested if same bug happens on other platforms.
